### PR TITLE
Add basic filtering to EconomicResources

### DIFF
--- a/src/zenflows/vf/economic_resource/domain.ex
+++ b/src/zenflows/vf/economic_resource/domain.ex
@@ -18,6 +18,8 @@
 defmodule Zenflows.VF.EconomicResource.Domain do
 @moduledoc "Domain logic of EconomicResources."
 
+import Ecto.Query
+
 alias Ecto.Multi
 alias Zenflows.DB.{Paging, Repo}
 alias Zenflows.VF.{
@@ -44,8 +46,17 @@ end
 
 @spec all(Paging.params()) :: Paging.result()
 def all(params) do
-	Paging.page(EconomicResource, params)
+	Paging.page(filter(params[:filter]), params)
 end
+
+defp filter(params) do
+	Enum.reduce(params || %{}, EconomicResource, &filt(&2, &1))
+end
+
+defp filt(q, {:classified_as, v}),       do: where(q, [x], fragment("? @> ?", x.classified_as, ^v))
+defp filt(q, {:primary_accountable, v}), do: where(q, [x], x.primary_accountable_id in ^v)
+defp filt(q, {:custodian, v}),           do: where(q, [x], x.custodian_id in ^v)
+defp filt(q, {:conforms_to, v}),         do: where(q, [x], x.conforms_to_id in ^v)
 
 @spec update(id(), params()) :: {:ok, EconomicResource.t()} | {:error, error()}
 def update(id, params) do

--- a/src/zenflows/vf/economic_resource/type.ex
+++ b/src/zenflows/vf/economic_resource/type.ex
@@ -235,6 +235,13 @@ object :economic_resource_connection do
 	field :edges, non_null(list_of(non_null(:economic_resource_edge)))
 end
 
+input_object :economic_resource_filter_params do
+	field :classified_as, list_of(non_null(:uri))
+	field :conforms_to, list_of(non_null(:id))
+	field :primary_accountable, list_of(non_null(:id))
+	field :custodian, list_of(non_null(:id))
+end
+
 object :query_economic_resource do
 	field :economic_resource, :economic_resource do
 		arg :id, non_null(:id)
@@ -246,6 +253,7 @@ object :query_economic_resource do
 		arg :after, :id
 		arg :last, :integer
 		arg :before, :id
+		arg :filter, :economic_resource_filter_params
 		resolve &Resolv.economic_resources/2
 	end
 end


### PR DESCRIPTION
Allows filtering by:
* ResourceSpecifications (product/service/design)
* Classifications (tags)
* PrimaryAccountables and Custodians (owners)
for: https://github.com/dyne/interfacer-gui/issues/16